### PR TITLE
Fix macOS trophy decryption

### DIFF
--- a/ftpdump
+++ b/ftpdump
@@ -1069,7 +1069,7 @@ replace_encrypted_trophies() {
   # Check previously downloaded npbind.dat for trophy directory names
   while read -r dir; do
     trophy_dirs+=($dir)
-  done < <(cat npbind.dat | strings | grep -E NPWR\[0-9\]{5}_\[0-9\]{2})
+  done < <(grep -E NPWR\[0-9\]{5}_\[0-9\]{2} < <(strings < npbind.dat))
   
   [[ $debug ]] && debug_message \
     "Trophy directories found in npbind.dat: ${trophy_dirs[*]}"

--- a/ftpdump
+++ b/ftpdump
@@ -1067,7 +1067,10 @@ replace_encrypted_trophies() {
   local trophy_file
 
   # Check previously downloaded npbind.dat for trophy directory names
-  readarray -t trophy_dirs < <(grep -aoE NPWR[0-9]{5}_[0-9]{2} npbind.dat)
+  while read -r dir; do
+    trophy_dirs+=($dir)
+  done < <(cat npbind.dat | strings | grep -E NPWR\[0-9\]{5}_\[0-9\]{2})
+  
   [[ $debug ]] && debug_message \
     "Trophy directories found in npbind.dat: ${trophy_dirs[*]}"
 


### PR DESCRIPTION
This resolves the following problems when running the script on macOS:
- Unescaped bracket chars `[ ]` in grep preventing processing
- Lack of 'readarray', regardless of bash version