### PR TITLE
Fix decryption of trophies when resuming a download

### DIFF
--- a/ftpdump
+++ b/ftpdump
@@ -572,6 +572,7 @@ dump_app_data() {
 
   if [[ -f npbind.dat ]]; then
     echo "Replacing npbind.dat and nptitle.dat ..."
+    rm npbind.dat nptitle.dat
     dump_file "$root/system_data/priv/appmeta/$1/npbind.dat"
     dump_file "$root/system_data/priv/appmeta/$1/nptitle.dat"
     replace_encrypted_trophies
@@ -612,6 +613,7 @@ dump_patch_data() {
 
     if [[ -f npbind.dat ]]; then
       echo "Replacing npbind.dat and nptitle.dat ..."
+      rm npbind.dat nptitle.dat
       dump_file "$root/system_data/priv/appmeta/$1/npbind.dat"
       dump_file "$root/system_data/priv/appmeta/$1/nptitle.dat"
       replace_encrypted_trophies


### PR DESCRIPTION
When resuming a download, the replacement of the encrypted npbind and nptitle files fails, and the original (encrypted) ones remain. I think it may be related to options that wget is ran with in dump_file, but didn't have much success there, and didn't want to risk introducing unexpected behaviour. If we remove the two encrypted files, then the replacement succeeds even when resuming a download.